### PR TITLE
Updating ground truth for Doulce Memoire and Ave Maria

### DIFF
--- a/intervals/data/cadences/CVFLabels.csv
+++ b/intervals/data/cadences/CVFLabels.csv
@@ -1,5 +1,6 @@
 Ngram,LowerCVF,UpperCVF
 "7_Held, 6_-2, 8",T,C
+" 7_1, 6_-2, 8 ",T,C
 "7_Held, 6_1, 6_-2, 8",T,C
 "7_Held, 6_Held, 6_-2, 8",T,C
 "7_Held, 6_Held, 5_-2, 8",T,C
@@ -9,6 +10,8 @@ Ngram,LowerCVF,UpperCVF
 "7_Held, 6_Held, 6_Held, 5_Held, 6_-2, 8",T,C
 "7_Held, 6_1, 6_Held, 5_Held, 6_-2, 8",T,C
 "8_Held, 7_Held, 6_-2, 8",,
+"6_Held, 5_-2, 6_-2, 8",T,C
+"6_-2, 6_-2, 7_2, 6_-2, 8",T,C
 "-7_-2, -6_2, -8",C,T
 "-7_-2, -6_-2, -5_3, -8",C,T
 "-7_-2, -6_-2, -5_2, -6_2, -8",C,T
@@ -29,6 +32,7 @@ Ngram,LowerCVF,UpperCVF
 "3_Held, 2_-2, 3_2, 3",C,t
 "1_Held, 2_-2, 3_2, 3",C,t
 "8_Held, 2_-2, 3_2, 3",C,t
+"8_-2, 2_-2, 3_-2, 3",,
 "Rest_Held, 2_-2, 3_2, 3",C,t
 "2_-2, 3_1, 3_-2, 4_2, 3_2, 3",C,t
 "-2_Held, -3_Rest|-2, Rest",z,c
@@ -55,7 +59,9 @@ Ngram,LowerCVF,UpperCVF
 "-6_-2, -5_Held, -6_Held, -6_Held, -7_-2, -4",T,A
 "-6_-2, -5_Held, -6_Held, -7_Held, -6_-2, -4",T,A
 "4_Held, 3_-5, 8",B,C
+"4_1, 3_-5, 8",B,C
 "5_Held, 4_Held, 3_-5, 8",,
+"5_2, 4_Held, 3_-5, 8",B,C
 "4_Held, 3_1, 3_-5, 8",B,C
 "4_Held, 3_Held, 3_-5, 8",B,C
 "4_Held, 3_Held, 2_-5, 8",B,C
@@ -79,6 +85,8 @@ Ngram,LowerCVF,UpperCVF
 "5_2, 4_Held, 3_Held, 2_Held, 3_2, 3",b,C
 "4_Held, 3_4, 8",B,C
 "4_Held, 3_4, 1",B,C
+"4_1, 3_4, 8",B,C
+"4_1, 3_4, 1",B,C
 "4_Held, 3_-3, 6",u,C
 "4_Held, 3_Held, 3_-3, 6",u,C
 "4_Held, 3_Held, 2_-3, 6",u,C


### PR DESCRIPTION
Doulce Memoire:
7_1, 6_-2, 8 T C
4_1, 3_-5, 8 B C
4_1, 3_4, 8 B C (not present but while we’re here I would include it)
4_1, 3_4, 1 B C (not present but while we’re here I would include it)

Ave Maria:
8_-2, 2_-2, 3_-2, 3	: false positive countermeasure via consonant prep, evaded cantizans (can also add a non-evaded version, but I’ll refrain till we come across one; already have such a version for tenorizans as lower voice)
5_2, 4_Held, 3_-5, 8 B C : Cons prep added to simple Authentic to catch earlier articulation of top voice (cadence was missed because cantizans 4th was held over from previous beat, not articulated simultaneously with bassizans ^5; you have several such what I call “cons prep” Ngrams, if I understand correctly, exactly for such cases)
6_Held, 5_-2, 6_-2, 8 T C : a CV variant with cantizans 7 anticipating tenorizans 2, no susp (this one might be problematically common in other, non-cadential, circumstances)
6_-2, 6_-2, 7_2, 6_-2, 8 T C : CV, a “chanson idiom” tenor (^4-^3-^2-^1-^2-^1; cf. Schubert textbook 148) where the Cantizans ^7 falls together with the first ^2, so no suspension.