### PR TITLE
fix HCDigitalScholarship/intervals#79

### DIFF
--- a/crim_intervals/main_objs.py
+++ b/crim_intervals/main_objs.py
@@ -315,7 +315,7 @@ class ImportedPiece:
 
     def _maxnDurationHelper(self, _col):
         col = _col.dropna()
-        starts = col[(col != 'Rest') & (col.shift(1).isin(('Rest', np.nan)))]
+        starts = col[(col != 'Rest') & (col.shift(1).isin(('Rest', None)))]
         ends = col[(col == 'Rest') & (col.shift(1) != 'Rest')]
         starts.dropna(inplace=True)
         ends.dropna(inplace=True)


### PR DESCRIPTION
Addressing [this](https://github.com/HCDigitalScholarship/intervals/issues/79).

The dtype of _col values is `object`.  The `col.shift(1)` created an additional "dummy" value with `None`. However, the code was looking for `np.nan` which was giving `False` and resulted in ignoring the first found melody.